### PR TITLE
Replace osc-ruby with fast_osc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "osc-ruby"
+gem "fast_osc"
 gem "eventmachine"

--- a/lib/sonic_pi.rb
+++ b/lib/sonic_pi.rb
@@ -1,6 +1,6 @@
 require 'socket'
 require 'rubygems'
-require 'osc-ruby'
+require 'fast_osc'
 require 'securerandom'
 
 class SonicPi

--- a/sonic-pi-cli.gemspec
+++ b/sonic-pi-cli.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'sonic-pi-cli'
-  s.version     = '0.1.0'
-  s.date        = '2016-11-10'
+  s.version     = '0.1.1'
+  s.date        = '2016-12-13'
   s.summary     = "Sonic Pi CLI"
   s.description = "A simple command line interface for Sonic Pi"
   s.authors     = ["Nick Johnstone"]
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://rubygems.org/gems/sonic-pi-cli'
   s.license     = 'MIT'
 
-  s.add_dependency 'osc-ruby'
+  s.add_dependency 'fast_osc'
 end


### PR DESCRIPTION
I believe `fast_osc` was written specifically for Sonic Pi, and is now the OSC library in Sonic Pi. It's significantly faster than `ruby-osc`, and is a drop-in replacement.